### PR TITLE
Support for multiple controllers

### DIFF
--- a/src/controller.c
+++ b/src/controller.c
@@ -48,36 +48,36 @@ int socket_connect(char *host, int portno) {
     return sockfd;
 }
 
-void clear_controller() {
-    controller[0].buttons.R_DPAD = 0;
-    controller[0].buttons.L_DPAD = 0;
-    controller[0].buttons.D_DPAD = 0;
-    controller[0].buttons.U_DPAD = 0;
-    controller[0].buttons.START_BUTTON = 0;
-    controller[0].buttons.Z_TRIG = 0;
-    controller[0].buttons.B_BUTTON = 0;
-    controller[0].buttons.A_BUTTON = 0;
-    controller[0].buttons.R_CBUTTON = 0;
-    controller[0].buttons.L_CBUTTON = 0;
-    controller[0].buttons.D_CBUTTON = 0;
-    controller[0].buttons.U_CBUTTON = 0;
-    controller[0].buttons.R_TRIG = 0;
-    controller[0].buttons.L_TRIG = 0;
-    controller[0].buttons.X_AXIS = 0;
-    controller[0].buttons.Y_AXIS = 0;
+void clear_controller(int Control) {
+    controller[Control].buttons.R_DPAD = 0;
+    controller[Control].buttons.L_DPAD = 0;
+    controller[Control].buttons.D_DPAD = 0;
+    controller[Control].buttons.U_DPAD = 0;
+    controller[Control].buttons.START_BUTTON = 0;
+    controller[Control].buttons.Z_TRIG = 0;
+    controller[Control].buttons.B_BUTTON = 0;
+    controller[Control].buttons.A_BUTTON = 0;
+    controller[Control].buttons.R_CBUTTON = 0;
+    controller[Control].buttons.L_CBUTTON = 0;
+    controller[Control].buttons.D_CBUTTON = 0;
+    controller[Control].buttons.U_CBUTTON = 0;
+    controller[Control].buttons.R_TRIG = 0;
+    controller[Control].buttons.L_TRIG = 0;
+    controller[Control].buttons.X_AXIS = 0;
+    controller[Control].buttons.Y_AXIS = 0;
 }
 
-void read_controller() {
+void read_controller(int Control) {
     int sockfd = socket_connect(HOST, PORT);
 
     if (sockfd == -1) {
-        clear_controller();
+        clear_controller(Control);
         return;
     }
 
     int bytes, sent, received, total;
     char message[1024], response[4096]; // allocate more space than required.
-    sprintf(message, "GET / HTTP/1.0\r\n\r\n");
+    sprintf(message, "GET /%d HTTP/1.0\r\n\r\n", Control);
 
     /* send the request */
     total = strlen(message);
@@ -125,37 +125,37 @@ void read_controller() {
     DebugMessage(M64MSG_INFO, json_object_to_json_string(jsonObj));
 #endif
 
-    controller[0].buttons.R_DPAD = 
+    controller[Control].buttons.R_DPAD = 
         json_object_get_int(json_object_object_get(jsonObj, "R_DPAD"));
-    controller[0].buttons.L_DPAD = 
+    controller[Control].buttons.L_DPAD = 
         json_object_get_int(json_object_object_get(jsonObj, "L_DPAD"));
-    controller[0].buttons.D_DPAD = 
+    controller[Control].buttons.D_DPAD = 
         json_object_get_int(json_object_object_get(jsonObj, "D_DPAD"));
-    controller[0].buttons.U_DPAD = 
+    controller[Control].buttons.U_DPAD = 
         json_object_get_int(json_object_object_get(jsonObj, "U_DPAD"));
-    controller[0].buttons.START_BUTTON = 
+    controller[Control].buttons.START_BUTTON = 
         json_object_get_int(json_object_object_get(jsonObj, "START_BUTTON"));
-    controller[0].buttons.Z_TRIG = 
+    controller[Control].buttons.Z_TRIG = 
         json_object_get_int(json_object_object_get(jsonObj, "Z_TRIG"));
-    controller[0].buttons.B_BUTTON = 
+    controller[Control].buttons.B_BUTTON = 
         json_object_get_int(json_object_object_get(jsonObj, "B_BUTTON"));
-    controller[0].buttons.A_BUTTON = 
+    controller[Control].buttons.A_BUTTON = 
         json_object_get_int(json_object_object_get(jsonObj, "A_BUTTON"));
-    controller[0].buttons.R_CBUTTON = 
+    controller[Control].buttons.R_CBUTTON = 
         json_object_get_int(json_object_object_get(jsonObj, "R_CBUTTON"));
-    controller[0].buttons.L_CBUTTON = 
+    controller[Control].buttons.L_CBUTTON = 
         json_object_get_int(json_object_object_get(jsonObj, "L_CBUTTON"));
-    controller[0].buttons.D_CBUTTON = 
+    controller[Control].buttons.D_CBUTTON = 
         json_object_get_int(json_object_object_get(jsonObj, "D_CBUTTON"));
-    controller[0].buttons.U_CBUTTON = 
+    controller[Control].buttons.U_CBUTTON = 
         json_object_get_int(json_object_object_get(jsonObj, "U_CBUTTON"));
-    controller[0].buttons.R_TRIG = 
+    controller[Control].buttons.R_TRIG = 
         json_object_get_int(json_object_object_get(jsonObj, "R_TRIG"));
-    controller[0].buttons.L_TRIG = 
+    controller[Control].buttons.L_TRIG = 
         json_object_get_int(json_object_object_get(jsonObj, "L_TRIG"));
-    controller[0].buttons.X_AXIS = 
+    controller[Control].buttons.X_AXIS = 
         json_object_get_int(json_object_object_get(jsonObj, "X_AXIS"));
-    controller[0].buttons.Y_AXIS = 
+    controller[Control].buttons.Y_AXIS = 
         json_object_get_int(json_object_object_get(jsonObj, "Y_AXIS"));
 
     close(sockfd);

--- a/src/controller.h
+++ b/src/controller.h
@@ -1,6 +1,6 @@
 #ifndef __CONTROLLER_H__
 #define __CONTROLLER_H__
 
-void read_controller();
+void read_controller(int);
 
 #endif // __CONTROLLER_H__

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -11,7 +11,7 @@
 #include "controller.h"
 
 /* global data definitions */
-SController controller[1];  // 1 controller
+SController controller[NUM_CONTROLLERS];
 
 /* static data definitions */
 static void (*l_DebugCallback)(void *, int, const char *) = NULL;
@@ -91,15 +91,17 @@ EXPORT m64p_error CALL PluginGetVersion(m64p_plugin_type *PluginType, int *Plugi
 EXPORT void CALL InitiateControllers(CONTROL_INFO ControlInfo)
 {
     // reset controllers
-    memset(controller, 0, sizeof( SController ));
+    memset(controller, 0, NUM_CONTROLLERS * sizeof( SController ));
 
     // set our CONTROL struct pointers to the array that was passed in to this function from the core
     // this small struct tells the core whether each controller is plugged in, and what type of pak is connected
-    controller[0].control = ControlInfo.Controls;
+    for (int i = 0; i < NUM_CONTROLLERS; i++) {
+      controller[i].control = ControlInfo.Controls + i;
 
-    // init controller
-    controller[0].control->Present = 1;
-    controller[0].control->Plugin = PLUGIN_NONE;
+      // init controller
+      controller[i].control->Present = 1;
+      controller[i].control->Plugin = PLUGIN_NONE;
+    }
 
     DebugMessage(M64MSG_INFO, "%s version %i.%i.%i initialized.", PLUGIN_NAME, VERSION_PRINTF_SPLIT(PLUGIN_VERSION));
 }
@@ -171,13 +173,13 @@ EXPORT void CALL RomClosed(void)
 *******************************************************************/
 EXPORT void CALL GetKeys( int Control, BUTTONS *Keys )
 {
-    read_controller();
+    read_controller(Control);
 
     #ifdef _DEBUG
-      DebugMessage(M64MSG_VERBOSE, "Controller #%d value: 0x%8.8X", 0, *(int *)&controller[0].buttons );
+      DebugMessage(M64MSG_VERBOSE, "Controller #%d value: 0x%8.8X", 0, *(int *)&controller[Control].buttons );
     #endif
 
-    *Keys = controller[0].buttons;
+    *Keys = controller[Control].buttons;
 }
 
 /******************************************************************

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -4,6 +4,8 @@
 #include "m64p_plugin.h"
 #include "m64p_types.h"
 
+#define NUM_CONTROLLERS 4
+
 typedef struct
 {
     CONTROL *control; // pointer to CONTROL struct in Core library
@@ -11,7 +13,7 @@ typedef struct
 } SController;
 
 /* global data definitions */
-extern SController controller[1]; // 1 controller
+extern SController controller[NUM_CONTROLLERS];
 
 /* global function definitions */
 extern void DebugMessage(int level, const char *message, ...);


### PR DESCRIPTION
Plugin can now handle multiple controllers (specified by NUM_CONTROLLERS). Instead of attempting to retrieve controller input from localhost:8082/, it now appends the index of the given controller that it's looking for input from. For example, "localhost:8082/0" for the first controller, "localhost:8082/1" for the second controller, etc.