### PR TITLE
Free the JSON object memory

### DIFF
--- a/src/controller.c
+++ b/src/controller.c
@@ -156,5 +156,8 @@ void read_controller(int Control) {
     controller[Control].buttons.Y_AXIS = 
         json_object_get_int(json_object_object_get(jsonObj, "Y_AXIS"));
 
+    // Mark the JSON object to be freed:
+    json_object_put(jsonObj);
+    
     close(sockfd);
 }


### PR DESCRIPTION
For context, see the conversation in https://github.com/bzier/gym-mupen64plus/issues/80 regarding the memory leak, investigation and resolution.

According to [the docs](https://github.com/json-c/json-c#using-json-c-) for the `json-c` library,
> When you are done with the tree of objects, you call json_object_put() on just the root object to free it, which recurses down through any child objects calling json_object_put() on each one of those in turn.

This change marks the JSON object we parsed to be freed and resolves the memory leak.