### PR TITLE
Changed parsing of http response to allow for http headers

### DIFF
--- a/src/controller.c
+++ b/src/controller.c
@@ -111,9 +111,8 @@ void read_controller(int Control) {
 #endif
 
     /* parse the http response */
-    char *body = strtok(response, "\n");
-    for (int i = 0; i < 5; i++)
-        body = strtok(NULL, "\n");
+    char *body = strstr(response, "\r\n\r\n");
+    body = body + 4;
 
     /* parse the body of the response */
     json_object *jsonObj = json_tokener_parse(body);


### PR DESCRIPTION
Previously if the server sent back any headers, the http response body would not be properly parsed, as the code was set to parse a specific number of lines (instead of detecting where the http response body started).